### PR TITLE
fix: add ImportError handling and troubleshooting docs for terminal-ai

### DIFF
--- a/terminal-ai/README.md
+++ b/terminal-ai/README.md
@@ -34,6 +34,23 @@ python terminal.py find all large files
 - **Risk Warnings**: Shows potential dangers before execution
 - **Explanations**: Understand what each command does
 
+## Troubleshooting
+
+- **Missing API key (`ANTHROPIC_API_KEY not found`)**
+  Set the environment variable first: `export ANTHROPIC_API_KEY="your-key"`
+  Get your key at https://console.anthropic.com/
+
+- **anthropic package not installed**
+  Install it with: `pip install anthropic`
+
+- **API or network errors**
+  Terminal AI automatically retries Anthropic calls 3 times with a short backoff.
+  If errors persist, check your internet connection or try again later.
+
+- **Command timed out**
+  Shell commands are limited to 30 seconds to keep the experience responsive.
+  Try a narrower request or run the suggested command manually in your terminal.
+
 ## Common Uses
 
 ```bash

--- a/terminal-ai/terminal.py
+++ b/terminal-ai/terminal.py
@@ -1,7 +1,19 @@
 #!/usr/bin/env python3
 """Terminal AI - Natural language to shell commands in <100 lines."""
 import os, sys, subprocess, argparse, platform, time
-from anthropic import Anthropic, APIError
+
+try:
+    from anthropic import Anthropic, APIError
+except ImportError:
+    print(
+        "\n❌ anthropic package is not installed!\n\n"
+        "Install it with:\n"
+        "  pip install anthropic\n\n"
+        "Then set your API key:\n"
+        "  export ANTHROPIC_API_KEY=\"your-key\"\n"
+        "Get your key: https://console.anthropic.com/\n"
+    )
+    sys.exit(1)
 
 DANGEROUS_COMMANDS = ["rm -rf /", ":(){ :|:& };:", "dd if=/dev/zero", "mkfs", "fork bomb", "> /dev/sda"]
 MAX_RETRIES = 3


### PR DESCRIPTION
## Summary

Completes the error handling improvements requested in #26 with two remaining items:

### Code Change
- **Graceful ImportError handling**: When the `anthropic` package is not installed, the script now shows a friendly installation guide instead of crashing with a raw ModuleNotFoundError traceback. Matches the UX pattern already used for missing API keys.

### Documentation
- **Troubleshooting section** in `terminal-ai/README.md` covering four common scenarios: missing API key, missing package, API/network errors, and command timeout.

All other error handling from the issue (API key validation, network retry with backoff, empty input validation, command timeout, friendly error messages) was already implemented in commit 01cd2fe.

Closes #26